### PR TITLE
Ginfo Integration

### DIFF
--- a/serverthrall/conandb/__init__.py
+++ b/serverthrall/conandb/__init__.py
@@ -33,7 +33,7 @@ class ConanDbClient(object):
 
         characters = []
 
-        with sqlite3.connect('D:\\Documents\\GitHub\\serverthrall\\vendor\\server\\ConanSandbox\\Saved\\game.db') as connection:
+        with sqlite3.connect(self.db_path) as connection:
             for row in connection.cursor().execute(SQL):
                 characters.append({
                     'name': row[2],
@@ -46,6 +46,7 @@ class ConanDbClient(object):
                     'x': row[7],
                     'y': row[8],
                     'z': row[9]})
+
         return characters
 
 

--- a/serverthrall/conandb/__init__.py
+++ b/serverthrall/conandb/__init__.py
@@ -33,7 +33,7 @@ class ConanDbClient(object):
 
         characters = []
 
-        with sqlite3.connect(self.db_path) as connection:
+        with sqlite3.connect('D:\\Documents\\GitHub\\serverthrall\\vendor\\server\\ConanSandbox\\Saved\\game.db') as connection:
             for row in connection.cursor().execute(SQL):
                 characters.append({
                     'name': row[2],
@@ -46,7 +46,6 @@ class ConanDbClient(object):
                     'x': row[7],
                     'y': row[8],
                     'z': row[9]})
-
         return characters
 
 

--- a/serverthrall/plugins/apiuploader.py
+++ b/serverthrall/plugins/apiuploader.py
@@ -30,6 +30,7 @@ class ApiUploader(IntervalTickPlugin):
         config.set_default('server_id', '')
         config.set_default('last_sync_time', '')
         config.set_default('ginfo_group_uid', '')
+        config.set_default('ginfo_access_token', '')
         super(ApiUploader, self).__init__(config)
 
     def ready(self, steamcmd, server, thrall):
@@ -45,6 +46,7 @@ class ApiUploader(IntervalTickPlugin):
 
         self.client = ConanDbClient(db_path)
         self.ginfo_group_uid = self.config.get('ginfo_group_uid')
+        self.ginfo_access_token = self.config.get('ginfo_access_token')
 
         self.logger.info('Connecting to Database '+ self.DB_PATH)
 
@@ -81,8 +83,9 @@ class ApiUploader(IntervalTickPlugin):
 
         try:
             params ={'private_secret': self.private_secret}
-            if self.ginfo_group_uid and self.ginfo_group_uid != "":
+            if self.ginfo_group_uid and self.ginfo_group_uid != "" and self.ginfo_access_token and self.ginfo_access_token != "":
                 params['ginfo_group_uid'] = self.ginfo_group_uid
+                params['ginfo_access_token'] = self.ginfo_access_token
             requests.post(
                 url=(self.SERVER_THRALL_API_URL + '/api/%s/sync/characters') % self.server_id,
                 params=params,

--- a/serverthrall/plugins/apiuploader.py
+++ b/serverthrall/plugins/apiuploader.py
@@ -21,8 +21,8 @@ from requests.exceptions import ConnectionError
 class ApiUploader(IntervalTickPlugin):
 
     NO_SECRET = ''
-    SERVER_THRALL_API_URL = 'http://serverthrallapi.herokuapp.com'
-    # SERVER_THRALL_API_URL = 'http://localhost:8000'
+    # SERVER_THRALL_API_URL = 'http://serverthrallapi.herokuapp.com'
+    SERVER_THRALL_API_URL = 'http://192.168.1.145:8000/'
 
     def __init__(self, config):
         config.set_default('interval.interval_seconds', 60)
@@ -43,6 +43,10 @@ class ApiUploader(IntervalTickPlugin):
             raise Exception('Server DB not found at path %s' % db_path)
 
         self.client = ConanDbClient(db_path)
+        # TODO: Load Group UID from Config and gracefully ignore, if UID is not set in the config
+        self.ginfo_group_uid = '-Knj7Mt-7frt_Wtpvq_9'
+
+        self.client = ConanDbClient(self.DB_PATH)
 
     def is_registered(self):
         return self.config.get('private_secret') != self.NO_SECRET
@@ -76,7 +80,7 @@ class ApiUploader(IntervalTickPlugin):
         try:
             requests.post(
                 url=(self.SERVER_THRALL_API_URL + '/api/%s/sync/characters') % self.server_id,
-                params={'private_secret': self.private_secret},
+                params={'private_secret': self.private_secret, 'ginfo_group_uid': self.ginfo_group_uid},
                 json={'characters': characters})
         except ConnectionError:
             self.logger.error('Cant sync server to serverthrallapi')

--- a/serverthrall/plugins/apiuploader.py
+++ b/serverthrall/plugins/apiuploader.py
@@ -20,23 +20,24 @@ from requests.exceptions import ConnectionError
 
 class ApiUploader(IntervalTickPlugin):
 
-    NO_SECRET = ''
-    # SERVER_THRALL_API_URL = 'http://serverthrallapi.herokuapp.com'
-    SERVER_THRALL_API_URL = 'http://192.168.1.145:8000'
+    NO_VALUE = ''
+    SERVER_THRALL_API_URL = 'http://serverthrallapi.herokuapp.com'
 
     def __init__(self, config):
         config.set_default('interval.interval_seconds', 60)
-        config.set_default('private_secret', self.NO_SECRET)
-        config.set_default('server_id', '')
-        config.set_default('last_sync_time', '')
-        config.set_default('ginfo_group_uid', '')
-        config.set_default('ginfo_access_token', '')
+        config.set_default('private_secret', self.NO_VALUE)
+        config.set_default('server_id', self.NO_VALUE)
+        config.set_default('last_sync_time', self.NO_VALUE)
+        config.set_default('ginfo_group_uid', self.NO_VALUE)
+        config.set_default('ginfo_access_token', self.NO_VALUE)
         super(ApiUploader, self).__init__(config)
 
     def ready(self, steamcmd, server, thrall):
         super(ApiUploader, self).ready(steamcmd, server, thrall)
         self.server_id = self.config.get('server_id')
         self.private_secret = self.config.get('private_secret')
+        self.ginfo_group_uid = self.config.get('ginfo_group_uid')
+        self.ginfo_access_token = self.config.get('ginfo_access_token')
 
         db_path = os.path.join(self.thrall.config.get('conan_server_directory'),
             'ConanSandbox\\Saved\\game.db')
@@ -45,12 +46,9 @@ class ApiUploader(IntervalTickPlugin):
             raise Exception('Server DB not found at path %s' % db_path)
 
         self.client = ConanDbClient(db_path)
-        self.ginfo_group_uid = self.config.get('ginfo_group_uid')
-        self.ginfo_access_token = self.config.get('ginfo_access_token')
-
 
     def is_registered(self):
-        return self.config.get('private_secret') != self.NO_SECRET
+        return self.config.get('private_secret') != self.NO_VALUE
 
     def register(self):
         self.logger.info('Registering server with serverthrallapi.')
@@ -78,13 +76,17 @@ class ApiUploader(IntervalTickPlugin):
 
         characters = self.client.get_characters()
 
+        url = (self.SERVER_THRALL_API_URL + '/api/%s/sync/characters') % self.server_id
+
+        params = {'private_secret': self.private_secret}
+
+        if self.ginfo_group_uid != self.NO_VALUE and self.ginfo_access_token != "":
+            params['ginfo_group_uid'] = self.ginfo_group_uid
+            params['ginfo_access_token'] = self.ginfo_access_token
+
         try:
-            params ={'private_secret': self.private_secret}
-            if self.ginfo_group_uid and self.ginfo_group_uid != "" and self.ginfo_access_token and self.ginfo_access_token != "":
-                params['ginfo_group_uid'] = self.ginfo_group_uid
-                params['ginfo_access_token'] = self.ginfo_access_token
             requests.post(
-                url=(self.SERVER_THRALL_API_URL + '/api/%s/sync/characters') % self.server_id,
+                url=url,
                 params=params,
                 json={'characters': characters})
         except ConnectionError:

--- a/serverthrall/plugins/apiuploader.py
+++ b/serverthrall/plugins/apiuploader.py
@@ -46,6 +46,8 @@ class ApiUploader(IntervalTickPlugin):
         # TODO: Load Group UID from Config and gracefully ignore, if UID is not set in the config
         self.ginfo_group_uid = '-Knj7Mt-7frt_Wtpvq_9'
 
+        self.logger.info('Connecting to Database '+ self.DB_PATH)
+
         self.client = ConanDbClient(self.DB_PATH)
 
     def is_registered(self):

--- a/serverthrall/plugins/apiuploader.py
+++ b/serverthrall/plugins/apiuploader.py
@@ -25,7 +25,7 @@ class ApiUploader(IntervalTickPlugin):
     SERVER_THRALL_API_URL = 'http://192.168.1.145:8000'
 
     def __init__(self, config):
-        config.set_default('interval.interval_seconds', 5)
+        config.set_default('interval.interval_seconds', 60)
         config.set_default('private_secret', self.NO_SECRET)
         config.set_default('server_id', '')
         config.set_default('last_sync_time', '')
@@ -44,7 +44,6 @@ class ApiUploader(IntervalTickPlugin):
         if not os.path.exists(db_path):
             raise Exception('Server DB not found at path %s' % db_path)
 
-        self.logger.info('Connecting to Database '+ db_path)
         self.client = ConanDbClient(db_path)
         self.ginfo_group_uid = self.config.get('ginfo_group_uid')
         self.ginfo_access_token = self.config.get('ginfo_access_token')

--- a/serverthrall/plugins/apiuploader.py
+++ b/serverthrall/plugins/apiuploader.py
@@ -22,7 +22,7 @@ class ApiUploader(IntervalTickPlugin):
 
     NO_SECRET = ''
     # SERVER_THRALL_API_URL = 'http://serverthrallapi.herokuapp.com'
-    SERVER_THRALL_API_URL = 'http://192.168.1.145:8000/'
+    SERVER_THRALL_API_URL = 'http://192.168.1.145:8000'
 
     def __init__(self, config):
         config.set_default('interval.interval_seconds', 5)
@@ -44,13 +44,11 @@ class ApiUploader(IntervalTickPlugin):
         if not os.path.exists(db_path):
             raise Exception('Server DB not found at path %s' % db_path)
 
+        self.logger.info('Connecting to Database '+ db_path)
         self.client = ConanDbClient(db_path)
         self.ginfo_group_uid = self.config.get('ginfo_group_uid')
         self.ginfo_access_token = self.config.get('ginfo_access_token')
 
-        self.logger.info('Connecting to Database '+ self.DB_PATH)
-
-        self.client = ConanDbClient(self.DB_PATH)
 
     def is_registered(self):
         return self.config.get('private_secret') != self.NO_SECRET


### PR DESCRIPTION
As discussed, here's the WIP pull request for my changes with the integration into the [https://conanexiles.ginfo.gg](Ginfo Map).

For the integration, its necessary to add two additional configuration settings:
* `ginfo_group_uid`: The UID of the Group to which the marker should be posted
* `ginfo_access_token`: An access token (specific for the group) that allows the API to post to this group.

The rest of the integration is implemented in the serverthrallapi: 
https://github.com/NullSoldier/serverthrallapi/pull/1


### Testing

I have deployed a beta update to [https://conanexiles-beta.ginfo.gg](https://conanexiles-beta.ginfo.gg).

You will need to create a group (or be admin of an existing group)
In the details panel of your group, click the "More" button at the top right and "Manage Access" (This will only show up if you're admin of the group).

<img width="433" alt="screen shot 2017-07-01 at 16 01 21" src="https://user-images.githubusercontent.com/3407787/27762658-a89f651c-5e76-11e7-86c9-10c6946f0e26.png">

The dialog displays your group's UID that you'll need to set for `ginfo_group_uid`.
Click "Create Access Token".

<img width="503" alt="screen shot 2017-07-01 at 16 03 26" src="https://user-images.githubusercontent.com/3407787/27762676-d8f0c102-5e76-11e7-9cf9-09b78bf27dde.png">

This is the token you'll need to set for `ginfo_access_token`.


That's it, serverthrall should now be able to post positions of your server to your ginfo group.


I'm curios about your feedback! 😄 