### PR TITLE
Add ServerConfig Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 serverthrall.config
 serverthrall.log
 vendor/
+virtualenv/
 
 # for jason only, remove later
 notes/

--- a/README.md
+++ b/README.md
@@ -19,34 +19,53 @@ Conan Server Manager (now known as Server Thrall) is a python based dedicated se
 | **UptimeTracker** | Records the percentage of time the server has been online. If the server thrall is closed, this counts against the uptime percentage. | **enabled**: Set to true or false to prevent this plugin from running<br>**seconds_up**: The total amount of seconds the server has been up<br>**initial**:  unix timestamp of when the server uptime started to be recorded. Delete this to restart your uptime counter |
 | **RaidPlugin** | Allows you to set a period of time under which "Raiding" is enabled. This means that building damage will only be enabled during this time. Works by changing the games configuration and rebooting the server at the boundries of raiding times. This plugin modifies the CanDamagePlayerOwnedStructures option in ServerSettings. | **enabled**: Set to true or false to prevent this plugin from running<br>**start_hour**: The hour of the day that raiding should be enabled. This should be in 24 hour time. So 17 would be 5pm in the servers computers timezone.<br>**length_in_hours**: The number of hours after start_hour that raiding should be enabled. |
 | **ApiUploader** | Uploads your server data to serverthrallapi so you can see your data online. If your **server_id** was `2`, and your **private_secret** was `200cd768-5b1d-11e7-9e82-d60626067254` you would access your servers characters at this URL: https://serverthrallapi.herokuapp.com/api/2/characters?private_secret=200cd768-5b1d-11e7-9e82-d60626067254  | **enabled**: Set to true or false to prevent this plugin from running<br>**server_id**: The registered server id with serverthrallapi, used to access your data.<br>**public_secret**: A public code you can give to your players to access a "public" view of your servers data. This is unused but will be used later.<br>**private_secret** A secret code that is used to make modifications to your server and synchronize data. Do NOT give this out to your players |
+| **ServerConfig** | Allows you to configure common server settings from your server thrall config. If the config differs from expected, the config will be edited and the server restarted. **NOTE** This even works for NetServerMaxTickRate which needs to be written to DefaultEngine, but all other settings get written to saved settings. |**enabled**: Set to true or false to prevent this plugin from running<br> **ServerName**=My Server: Sets the name that will be displayed in the server list.<br> **ServerPassword**=Password123: Sets the server password that will need to be entered to join the server. Leave blank for no password.<br> **GameServerQueryPort**=27015: Sets the query port for Steam matchmaking. Same as setting -QueryPort in the command line.<br> **Port**=7777: Sets the game server port.<br> **MaxPlayers**=70: Sets the maximum number of players.<br> **AdminPassword**=SecretPassword: Sets the administrative password for the server. This will grant players administrative rights when used from the settings menu in-game.<br> **MaxNudity**=2: Sets the maximum nudity level allowed on the server. (0=None, 1=Partial, 2=Full)<br> **IsBattleEyeEnabled**=True: Enables/disables BattlEye protection for the server.<br> **ServerRegion**=1: Sets the server's region. (0=EU, 1=NA, 2=Asia)<br> **ServerCommunity**=1: Sets the server's play style (0=None, 1=Purist, 2=Relaxed, 3=Hard Core, 4=Role Playing, 5=Experimental)<br> **PVPBlitzServer**=False: Enables/disables Blitz mode. (accelerated progression)<br> **PVPEnabled**=True: Enables/disables PvP on the server.<br> **NetServerMaxTickRate**=30: Sets the maximum tick rate (update rate) for the server. **WARNING**: High values can cause unwanted behavior.<br> |
 
 
 ### Example Config
 ```ini
 [ServerThrall]
 force_update_on_launch = false
-conan_server_directory = c:\..\conan\vendor\server
-additional_arguments = -MULTIHOME=192.168.2.4 -QueryPort=27019 -GameServerQueryPort=27020 -ServerName=FooServer -MaxPlayers=20
+conan_server_directory = c:\Users\Jason\Desktop\Projects\serverthrall\vendor\server
+additional_arguments = -MULTIHOME=192.168.2.15
+
 [UptimeTracker]
 initial = 1487425465.0
 seconds_up = 1261.0
-enabled = false
+enabled = true
+
 [DownRecovery]
 enabled = true
+
 [ServerUpdater]
 enabled = true
-installed_version = 1643774
+installed_version = 1933316
+
 [RaidManager]
 enabled = true
 start_hour = 17
 length_in_hours = 5
+
+[ApiUploader]
+enabled = true
+
+[ServerConfig]
+enabled = true
+ServerName = Awesome Server
+NetServerMaxTickRate = 90
+MaxPlayers = 8
+AdminPassword = 123456
+MaxNudity = 2
+PVPBlitzServer = False
+PVPEnabled = True
+ServerCommunity = 1
+IsBattleEyeEnabled = True
 ```
 
 ### Coming Soon
- * Discord integration
- * Server event stream
-   * Players logging in / out
-   * Player deaths
+ * [GInfo integration](https://conanexiles.ginfo.gg)
+ * Access your server data from an online REST API
+ * Online UI to audit your player's actions
 
 ### Example Log
 ```sh

--- a/install_and_run.bat
+++ b/install_and_run.bat
@@ -1,4 +1,3 @@
-pip install steamfiles==0.1.1
 pip install flake8==3.3.0
 pip install isort==4.2.5
 pip install psutil==5.1.3
@@ -6,4 +5,5 @@ pip install requests==2.18.1
 
 @echo off
 echo Installation complete.
-pause>nul
+
+./runserver.bat

--- a/serverthrall/__main__.py
+++ b/serverthrall/__main__.py
@@ -2,7 +2,7 @@
 from .appconfig import config_load, ThrallConfig, PluginConfig
 from .conanconfig import ConanConfig
 from .conanserver import ConanServer
-from .plugins import UptimeTracker, DownRecovery, ServerUpdater, RaidManager, ApiUploader
+from .plugins import UptimeTracker, DownRecovery, ServerUpdater, RaidManager, ApiUploader, ServerConfig
 from .thrall import Thrall
 from .steamcmd import SteamCmd
 import settings
@@ -12,6 +12,7 @@ import logging
 import atexit
 
 INSTALLED_PLUGINS = (
+    ServerConfig,
     UptimeTracker,
     DownRecovery,
     ServerUpdater,

--- a/serverthrall/appconfig/util.py
+++ b/serverthrall/appconfig/util.py
@@ -14,6 +14,8 @@ def config_save(config):
 
 def config_load():
     config = ConfigParser.RawConfigParser()
+    config.optionxform = str
+
     try:
         with open(settings.CONFIG_NAME) as f:
             config.readfp(f)

--- a/serverthrall/plugins/__init__.py
+++ b/serverthrall/plugins/__init__.py
@@ -1,6 +1,7 @@
 #flake8: noqa
+from .apiuploader import ApiUploader
 from .downrecovery import DownRecovery
 from .raidmanager import RaidManager
+from .serverconfig import ServerConfig
 from .serverupdater import ServerUpdater
 from .uptimetracker import UptimeTracker
-from .apiuploader import ApiUploader

--- a/serverthrall/plugins/raidmanager.py
+++ b/serverthrall/plugins/raidmanager.py
@@ -1,6 +1,5 @@
 from .thrallplugin import ThrallPlugin
 from datetime import datetime, timedelta
-import ConfigParser
 import os
 
 

--- a/serverthrall/plugins/serverconfig.py
+++ b/serverthrall/plugins/serverconfig.py
@@ -1,0 +1,56 @@
+from .thrallplugin import ThrallPlugin
+from ConfigParser import NoOptionError, NoSectionError
+
+
+class ServerConfig(ThrallPlugin):
+
+    CONFIG_MAPPING = {
+        'ServerName':           ('Engine', 'OnlineSubsystemSteam', 'ServerName'),
+        'ServerPassword':       ('Engine', 'OnlineSubsystemSteam', 'ServerPassword'),
+        'GameServerQueryPort':  ('Engine', 'OnlineSubsystemSteam', 'GameServerQueryPort'),
+        'Port':                 ('Engine', 'URL', 'Port'),
+        'MaxPlayers':           ('Game', '/Script/Engine.GameSession', 'MaxPlayers'),
+        'AdminPassword':        ('ServerSettings', 'ServerSettings', 'AdminPassword'),
+        'MaxNudity':            ('ServerSettings', 'ServerSettings', 'MaxNudity'),
+        'IsBattleEyeEnabled':   ('ServerSettings', 'ServerSettings', 'IsBattleEyeEnabled'),
+        'ServerRegion':         ('ServerSettings', 'ServerSettings', 'ServerRegion'),
+        'ServerCommunity':      ('ServerSettings', 'ServerSettings', 'ServerCommunity'),
+        'PVPBlitzServer':       ('ServerSettings', 'ServerSettings', 'PVPBlitzServer'),
+        'PVPEnabled':           ('ServerSettings', 'ServerSettings', 'PVPEnabled'),
+        'NetServerMaxTickRate': ('Engine', '/Script/OnlineSubsystemUtils.IpNetDriver', 'NetServerMaxTickRate'),
+    }
+
+    FIRST_WHITE_LIST = ('NetServerMaxTickRate',)
+
+    def config_get_safe(self, src):
+        try:
+            return self.config.get(src)
+        except NoOptionError:
+            return None
+
+    def sync_mapping(self,mapping):
+        changed = False
+
+        for src, dest in self.CONFIG_MAPPING.iteritems():
+            group, section, option = dest
+
+            value = self.config_get_safe(src)
+            original = self.thrall.conan_config.get(group, section, option)
+
+            path = '%s/%s/%s=%s'
+
+            if value is not None and value != original:
+                self.logger.info('Syncing option %s to %s/%s/%s as %s' % (src, group, section, option, value))
+                self.thrall.conan_config.set(group, section, option, value, option in self.FIRST_WHITE_LIST)
+                changed = True
+
+        return changed
+
+    def tick(self):
+        changed = self.sync_mapping(self.CONFIG_MAPPING)
+
+        if changed:
+            self.thrall.conan_config.save()
+            self.logger.info('Restarting server for config to take into affect')
+            self.server.close()
+            self.server.start()


### PR DESCRIPTION
This plugin allows you to configure the most common settings directly from your ServerThrall config. Unlike other plugins, no options will be listed in the config by default. Only settings that you include will be synced. A list of options can be found in the readme.