### PR TITLE
Watch config files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 psutil==5.1.3
 requests==2.18.1
 steamfiles==0.1.3
+watchdog==0.8.3

--- a/serverthrall/__init__.py
+++ b/serverthrall/__init__.py
@@ -47,19 +47,19 @@ def run_server_thrall():
     if not server.is_installed():
         # Install the server if it's not installed
         logger.info('Conan server not installed, installing.')
+        server.close()
         server.install_or_update()
         server.start()
         conan_config.wait_for_configs_to_exist()
-        server.close()
         conan_config.refresh()
 
     elif thrall_config.getboolean('force_update_on_launch'):
         # user can force an update on launch if files are missing
         logger.info('Forcing update because you told me to do so in your configuration.')
+        server.close()
         server.install_or_update()
         server.start()
         conan_config.wait_for_configs_to_exist()
-        server.close()
         conan_config.refresh()
 
     else:

--- a/serverthrall/conanconfig/__init__.py
+++ b/serverthrall/conanconfig/__init__.py
@@ -101,8 +101,14 @@ class ConanConfig(object):
         # write modified config files out to the last config path in each group
         for group_key, group in self.groups.items():
             for group_index, group_config in enumerate(group):
-                with open(self.group_paths[group_key][group_index], 'w') as group_file:
-                    group_config.write(group_file)
+                is_modified = (
+                    group_key in self.dirty and
+                    len(self.dirty[group_key]) > group_index and
+                    self.dirty[group_key][group_index] != {})
+
+                if is_modified:
+                    with open(self.group_paths[group_key][group_index], 'w') as group_file:
+                        group_config.write(group_file)
 
         self.dirty = {}
 

--- a/serverthrall/plugins/serverconfig.py
+++ b/serverthrall/plugins/serverconfig.py
@@ -1,8 +1,40 @@
-from .thrallplugin import ThrallPlugin
+from .intervaltickplugin import IntervalTickPlugin
 from configparser import NoOptionError
+from contextlib import contextmanager
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+import os
 
 
-class ServerConfig(ThrallPlugin):
+class OnModifiedHandler(FileSystemEventHandler):
+
+    def __init__(self, plugin, paths, logger, *args, **kwargs):
+        super(OnModifiedHandler, self).__init__(*args, **kwargs)
+        self.plugin = plugin
+        self.paths = paths
+        self.logger = logger
+        self.ignore = False
+
+    def on_modified(self, ev):
+        if ev.src_path not in self.paths:
+            return
+
+        if self.ignore is True:
+            return
+
+        self.logger.info('got modification %s: %s' % (ev.event_type, ev.src_path))
+        self.plugin.tick_early()
+
+    @contextmanager
+    def ignore_modifications(self):
+        self.ignore = True
+        try:
+            yield
+        finally:
+            self.ignore = True
+
+
+class ServerConfig(IntervalTickPlugin):
 
     CONFIG_MAPPING = {
         'ServerName':           ('Engine', 'OnlineSubsystemSteam', 'ServerName'),
@@ -19,21 +51,57 @@ class ServerConfig(ThrallPlugin):
         'NetServerMaxTickRate': ('Engine', '/Script/OnlineSubsystemUtils.IpNetDriver', 'NetServerMaxTickRate'),
     }
 
-    DEFAULT_WHITE_LIST = []
+    DEFAULT_WHITE_LIST = ['Port']
+    FIVE_MINUTES = 5 * 60
 
-    def config_get_safe(self, src):
+    def __init__(self, config):
+        super(ServerConfig, self).__init__(config)
+        config.set_default('interval.interval_seconds', self.FIVE_MINUTES)
+        config.queue_save()
+
+    def ready(self, *args, **kwargs):
+        super(ServerConfig, self).ready(*args, **kwargs)
+
+        config_paths = self.get_conan_config_paths(self.thrall.conan_config)
+        self.handler = OnModifiedHandler(self, config_paths, self.logger)
+
+        default_config_dir = os.path.join(self.thrall.config.get('conan_server_directory'), 'ConanSandbox\\Config')
+        derived_config_dir = os.path.join(self.thrall.config.get('conan_server_directory'), 'ConanSandbox\\Saved\\Config\\WindowsServer')
+
+        self.observer = Observer()
+        self.observer.schedule(self.handler, path=default_config_dir, recursive=False)
+        self.observer.schedule(self.handler, path=derived_config_dir, recursive=False)
+        self.observer.start()
+
+        self.tick_early()
+
+    def unload(self, *args, **kwargs):
+        if self.observer is not None:
+            self.observer.stop()
+            self.observer.join()
+
+    def get_conan_config_paths(self, conan_config):
+        config_paths = []
+
+        for group_name, group_paths in self.thrall.conan_config.group_paths.items():
+            for group_path in group_paths:
+                config_paths.append(group_path)
+
+        return config_paths
+
+    def get_config_value_safe(self, src):
         try:
             return self.config.get(src)
         except NoOptionError:
             return None
 
-    def sync_mapping(self, mapping):
+    def sync(self):
         changed = False
 
         for src, dest in self.CONFIG_MAPPING.items():
             group, section, option = dest
 
-            value = self.config_get_safe(src)
+            value = self.get_config_value_safe(src)
             original = self.thrall.conan_config.get(group, section, option)
 
             if value is not None and value != original:
@@ -44,12 +112,13 @@ class ServerConfig(ThrallPlugin):
 
         return changed
 
-    def tick(self):
+    def tick_interval(self):
         self.thrall.conan_config.refresh()
-        changed = self.sync_mapping(self.CONFIG_MAPPING)
+        changed = self.sync()
 
         if changed:
             self.logger.info('Restarting server for config to take into affect')
             self.server.close()
-            self.thrall.conan_config.save()
+            with self.handler.ignore_modifications():
+                self.thrall.conan_config.save()
             self.server.start()

--- a/serverthrall/plugins/thrallplugin.py
+++ b/serverthrall/plugins/thrallplugin.py
@@ -16,3 +16,6 @@ class ThrallPlugin(object):
         self.thrall = thrall
         self.logger = logging.getLogger('serverthrall.' + self.name)
         self.logger.setLevel(logging.INFO)
+
+    def unload(self):
+        pass

--- a/serverthrall/thrall.py
+++ b/serverthrall/thrall.py
@@ -40,6 +40,7 @@ class Thrall(object):
                 except Exception:
                     self.logger.exception('Unloading %s plugin after error ' % plugin.name)
                     self.plugins.remove(plugin)
+                    plugin.unload()
 
         while True:
             for plugin in self.plugins:
@@ -51,6 +52,7 @@ class Thrall(object):
                 except Exception:
                     self.logger.exception('Unloading %s plugin after error ' % plugin.name)
                     self.plugins.remove(plugin)
+                    plugin.unload()
 
             self.config.save_if_queued()
             time.sleep(0.16)


### PR DESCRIPTION

This is one of the final last major changes and optimizations to server thrall in preparation for ServerThrall 2.0 Instead of polling and refreshing the configs manually, this brings in the Python watchdogs library to watch the config files in conan and only refresh / update them when they change. It also falls back to a 5 minute poll in case the file watcher misses something.