### PR TITLE
Attempted fix for passing non str to steamfiles

### DIFF
--- a/serverthrall/__init__.py
+++ b/serverthrall/__init__.py
@@ -8,6 +8,7 @@ from configparser import ConfigParser
 import atexit
 import logging
 import os
+import sys
 from . import settings
 
 INSTALLED_PLUGINS = (
@@ -21,6 +22,10 @@ INSTALLED_PLUGINS = (
 
 def run_server_thrall():
     logger = logging.getLogger('serverthrall')
+    logger.debug('Starting serverthrall with python %s.%s.%s' % (
+        sys.version_info[0],
+        sys.version_info[1],
+        sys.version_info[2]))
 
     config = config_load()
     config_is_new = False

--- a/serverthrall/steamcmd.py
+++ b/serverthrall/steamcmd.py
@@ -46,7 +46,7 @@ class SteamCmd(object):
             'app_info_update 1',
             'app_info_print %s' % app_id,
             'app_info_print %s' % app_id,
-            'quit').split('\n')
+            'quit').splitlines()
 
         first_index = None
         last_index = None
@@ -64,7 +64,7 @@ class SteamCmd(object):
             raise Exception('couldnt parse steamcmd app_info output')
 
         acf_output = output[first_index + 1:last_index]
-        return acf.loads('\n'.join(acf_output))
+        return acf.loads(str('\n'.join(acf_output)))
 
     def update_app(self, app_id, app_dir):
         self.try_delete_cache()


### PR DESCRIPTION
 - [x] Add debug log to ensure running on 3.6.1 in installer
 - [x] Cast value to str as a bandaid
 - [x] Use new python3 functions to try to ensure using str and not bytes

Hopefully fixes https://github.com/NullSoldier/serverthrall/issues/39