### PR TITLE
Read conan config as utf-8 sig

### DIFF
--- a/serverthrall/conanconfig/__init__.py
+++ b/serverthrall/conanconfig/__init__.py
@@ -35,7 +35,7 @@ class ConanConfig(object):
 
             for path in paths:
                 config = ConanConfigParser()
-                files_read = config.read(path)
+                files_read = config.read(path, 'utf-8-sig')
                 groups[key].append(config)
 
                 if len(files_read) == 0:


### PR DESCRIPTION
There are some users who's config files are written with BOM markers. Python supports using utf-8 sig to detect BOM markers first, and if so switch the encoding to the correct endianness and encoding. This will cause certain users conan configs to not crash when being read.